### PR TITLE
Add chat message and event tables to db

### DIFF
--- a/server/src/db/sql.ts
+++ b/server/src/db/sql.ts
@@ -1,6 +1,8 @@
 import { createPool, PoolConnection, QueryOptions } from 'mysql2'
 import { createConnection } from 'typeorm'
+import { ChatMessage } from '../entities/ChatMessage'
 import { Event } from '../entities/Event'
+import { EventTable } from '../entities/EventTable'
 import { EventUserConfig } from '../entities/EventUserConfig'
 import { Session } from '../entities/Session'
 import { Survey } from '../entities/Survey'
@@ -22,7 +24,7 @@ export async function initORM() {
     username: process.env.MYSQL_USER || 'root',
     synchronize: true,
     logging: false,
-    entities: [User, Session, Survey, SurveyQuestion, SurveyAnswer, EventUserConfig, Event],
+    entities: [User, Session, Survey, SurveyQuestion, SurveyAnswer, EventUserConfig, Event, ChatMessage, EventTable],
     extra: {
       connectionLimit: 5,
     },

--- a/server/src/entities/ChatMessage.ts
+++ b/server/src/entities/ChatMessage.ts
@@ -1,0 +1,27 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+import { Event } from './Event'
+import { EventTable } from './EventTable'
+import { User } from './User'
+
+@Entity()
+export class ChatMessage extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @ManyToOne(() => User, user => user.chatMessages)
+  user: User
+
+  @Column({
+    length: 500
+  })
+  message: string
+
+  @UpdateDateColumn()
+  timeSent: Date
+
+  @ManyToOne(() => Event, event => event.chatMessages)
+  event: Event
+
+  @ManyToOne(() => EventTable, tbl => tbl.chatMessages)
+  table: EventTable
+}

--- a/server/src/entities/Event.ts
+++ b/server/src/entities/Event.ts
@@ -1,4 +1,5 @@
 import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+import { ChatMessage } from './ChatMessage'
 import { EventUserConfig } from './EventUserConfig'
 
 @Entity()
@@ -28,7 +29,7 @@ export class Event extends BaseEntity {
   endTime: Date
 
   @Column('int')
-  capacity: number
+  userCapacity: number
 
   // deal with this later
   @Column({ default: false })
@@ -36,4 +37,7 @@ export class Event extends BaseEntity {
 
   @OneToMany(() => EventUserConfig, eventUserConfig => eventUserConfig.event)
   eventUserConfigs: EventUserConfig[]
+
+  @OneToMany(() => ChatMessage, msg => msg.event)
+  chatMessages: ChatMessage[]
 }

--- a/server/src/entities/EventTable.ts
+++ b/server/src/entities/EventTable.ts
@@ -1,0 +1,27 @@
+import { BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
+import { ChatMessage } from './ChatMessage'
+import { User } from './User'
+
+@Entity()
+export class EventTable extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @Column()
+  name: string
+
+  @Column({
+    type: 'text',
+    nullable: true,
+  })
+  description: string
+
+  @Column('int')
+  userCapacity: number
+
+  @OneToMany(() => ChatMessage, msg => msg.event)
+  chatMessages: ChatMessage[]
+
+  @ManyToOne(() => User, user => user.tables)
+  head: EventTable
+}

--- a/server/src/entities/User.ts
+++ b/server/src/entities/User.ts
@@ -1,5 +1,7 @@
 import { BaseEntity, Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
 import { User as GraphqlUser, UserType } from '../graphql/schema.types'
+import { ChatMessage } from './ChatMessage'
+import { EventTable } from './EventTable'
 import { EventUserConfig } from './EventUserConfig'
 
 @Entity()
@@ -38,4 +40,10 @@ export class User extends BaseEntity implements GraphqlUser {
 
   @OneToMany(() => EventUserConfig, eventUserConfig => eventUserConfig.user)
   eventUserConfigs: EventUserConfig[]
+
+  @OneToMany(() => ChatMessage, msg => msg.user)
+  chatMessages: ChatMessage[]
+
+  @OneToMany(() => EventTable, tbl => tbl.head)
+  tables: EventTable[]
 }


### PR DESCRIPTION
Use case: We want to store chat messages so when a user joins the table, they can see previous messages and get extra context. Will also help admins in monitoring chat.

Couple things to note:
- Retrieving old chat messages of a user/event/table can grow very large, later on need to consider lazy loading and pagination of chat messages
- Should clear events/tables/messages older than some point in time (say 60 days) (and make that clear to the user when they use the app)